### PR TITLE
Fix light/dark mode state github icon

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,14 +16,13 @@ interface Palette {
   color: string;
 }
 
-const lightTheme: Palette = {
-  // background: "linen",
+export const lightTheme: Palette = {
   mode: "light",
   background: "#f7f6f2",
   color: "#212118",
 };
 
-const darkTheme: Palette = {
+export const darkTheme: Palette = {
   mode: "dark",
   background: "#212118",
   color: "linen",

--- a/src/components/LightDarkModeMUISwitch.tsx
+++ b/src/components/LightDarkModeMUISwitch.tsx
@@ -27,7 +27,7 @@ const LightDarkModeMUISwitch = styled(Switch)(
         "& + .MuiSwitch-track": {
           opacity: 1,
           // backgroundColor: theme.mode === "dark" ? "#8796A5" : "#aab4be",
-          backgroundColor: theme.mode === "dark" ? "linen" : "#aab4be",
+          backgroundColor: "#aab4be",
         },
       },
     },
@@ -53,7 +53,7 @@ const LightDarkModeMUISwitch = styled(Switch)(
     "& .MuiSwitch-track": {
       opacity: 1,
       // backgroundColor: theme.mode === "dark" ? "#8796A5" : "#aab4be",
-      backgroundColor: theme.mode === "dark" ? "green" : "#aab4be",
+      backgroundColor: "#aab4be",
       borderRadius: 20 / 2,
     },
   })

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -41,7 +41,7 @@ const LeftNavItems = ({ palette }: { palette: Palette }) => {
         >
           <img
             src={
-              palette.background === "linen"
+              palette.mode === "light"
                 ? githubIconLightMode
                 : githubIconDarkMode
             }
@@ -181,13 +181,13 @@ export default function NavBar({ palette }: { palette: Palette }) {
 
   if (isOpen) {
     mobileNavIcon =
-      palette.background === "linen" ? NavLightModeOpened : NavDarkModeOpened;
+      palette.mode === "light" ? NavLightModeOpened : NavDarkModeOpened;
   }
 
   function clickNavOpener() {
     console.log("prev was", isOpen);
     mobileNavIcon =
-      palette.background === "linen" ? NavLightModeClosed : NavDarkModeClosed;
+      palette.mode === "light" ? NavLightModeClosed : NavDarkModeClosed;
     setIsOpen(!isOpen);
   }
 

--- a/src/components/WhereSection.tsx
+++ b/src/components/WhereSection.tsx
@@ -71,7 +71,7 @@ export default function WhereSection({ palette }: { palette: Palette }) {
           >
             <img
               src={
-                palette.background === "linen"
+                palette.mode === "light"
                   ? githubIconLightMode
                   : githubIconDarkMode
               }


### PR DESCRIPTION
## Description:
Previously, the light/dark mode icon status was dependent on the _hard-coded colour_ of the light/dark mode theme. This was not good practice, as if the colour changed (as defined in `lightTheme` and `darkTheme`), all instances of the hard-coded colour would have to be updated manually to maintain the logic.

This PR modifies the icon light/dark mode changing logic to depend on the variable `palette.mode` (which can be `light` or `dark`) directly, so no hard-coding or multiple-place modifications are required with a colour change.